### PR TITLE
Add maintainer to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Predictionpackr
 Version: 0.1.0
 Author: Celina Lindgren
-Maintainer: 
+Maintainer: Celina Lindgren
 Description: Package including all functions used in the project "Prediction models vs. clinicians"
 License: What license is it under?
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: predictionpackr
 Type: Package
 Title: Predictionpackr
 Version: 0.1.0
-Author: Celina Lindgren
-Maintainer: Celina Lindgren
+Author: c(person("Celina", "Lindgren", email = "celinasemail@celinasemail.com", role = c("aut", "cre")))
+Maintainer: Celina Lindgren <celinasemail@celinasemail.com>
 Description: Package including all functions used in the project "Prediction models vs. clinicians"
 License: What license is it under?
 Encoding: UTF-8


### PR DESCRIPTION
To fix the Malinformed maintainer field error when using
devtools::install_github.